### PR TITLE
Update react-native peer dependency version and remove react-native-windows peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-config-reader",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Simply access android build configs and ios info.plist values in JS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "csath - chanakaathurugiriya@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.650 || ^0.66.0",
-    "react-native-windows": "^0.41.0 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.650 || ^0.66.0"
+    "react-native": "^0.41.2 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0",
+    "react-native-windows": "^0.41.0 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "author": "csath - chanakaathurugiriya@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0",
-    "react-native-windows": "^0.41.0 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
+    "react-native": "^0.41.2 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a PR to address issue #30. It also removes `react-native-windows` as a peer dependency, as that doesn't seem to offer any value.