### PR TITLE
fix: address Expo 44 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A native library to access all the native code's build configurations from JS.
 
-
 For **react-native@0.60+** versions use **react-native-config-reader@4.0+**
-(Autolinking support enabled now)
+(autolinking support enabled now).
 
+🚨 Seeking help maintaining `react-native-windows` compatibility. See [below](#windows-beta).
 
 ## Installation
 
 For **rn 0.60+ Auto Linking** will do things for you.
 
-If not follow these: 
+If not, follow these:
 
 1. `$ npm install react-native-config-reader --save` or  `$ yarn add react-native-config-reader`
 
@@ -24,13 +24,12 @@ If not follow these:
 See [manual installation](#manual-installation) below if you have issues with `react-native link`.
 
 ## Usage
+
 ```javascript
 import RNConfigReader from 'react-native-config-reader';
 
-// access any of the defined config variables in andoird build gradle or ios info.plist
+// access any of the defined config variables in Android build gradle or iOS info.plist
 const configValue = RNConfigReader.ANY_DEFINED_CONFIG_FIELD;
-
-
 ```
 
 ### More examples
@@ -44,86 +43,86 @@ android {
         applicationId "com.react-native.react-native-config-reader"
         versionCode 1
         versionName "1.0"
-        
+
         buildConfigField "String", "TEST_CONFIG_FIELD", "Hello I'm your test config value"
     }
 }
-
 ```
+
 Create new field inside ios `info.plist` file
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 
-<plist version="1.0"> 
+<plist version="1.0">
 <dict>
-  	<key>CFBundleDisplayName</key>
-	<string>com.react-native.react-native-config-reader</string>
-  
-	<key>TEST_CONFIG_FIELD</key>
-	<string>"Hello I'm your test config value"</string>
+   <key>CFBundleDisplayName</key>
+   <string>com.react-native.react-native-config-reader</string>
+
+   <key>TEST_CONFIG_FIELD</key>
+   <string>"Hello I'm your test config value"</string>
 </dict>
 </plist>
-
-
 ```
 
-Now you can acess them inside the JS code
+Now you can access them inside the JS code:
 
 ```javascript
 import { Platform } from 'react-native';
 import RNConfigReader from 'react-native-config-reader';
 
-if(Platform.OS === 'ios') {
+if (Platform.OS === 'ios') {
   const iosBundleDisplayName = RNConfigReader.CFBundleDisplayName;
   const testConfigValue = RNConfigReader.TEST_CONFIG_FIELD;
 }
 
-if(Platform.OS === 'android') {
+if (Platform.OS === 'android') {
   const androidApplicationID = RNConfigReader.applicationId;
   const testConfigValue = RNConfigReader.TEST_CONFIG_FIELD;
 }
-
-
 ```
 
 ## Manual installation
 
-
-#### iOS
+### iOS
 
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-config-reader` and add `RNConfigReader.xcodeproj`
 3. In XCode, in the project navigator, select your project. Add `libRNConfigReader.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project (`Cmd+R`)<
+4. Run your project (`Cmd+R`)
 
-#### Android
+### Android
 
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
+
   - Add `import com.reactlibrary.RNConfigReaderPackage;` to the imports at the top of the file
   - Add `new RNConfigReaderPackage()` to the list returned by the `getPackages()` method
-2. Append the following lines to `android/settings.gradle`:
-  	```
-  	include ':react-native-config-reader'
-  	project(':react-native-config-reader').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-config-reader/android')
-  	```
-3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
-  	```
-      compile project(':react-native-config-reader')
-  	```
 
-##### Android advanced configurations with Multiple environments
+1. Append the following lines to `android/settings.gradle`:
+
+   ```gradle
+   include ':react-native-config-reader'
+   project(':react-native-config-reader').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config-reader/android')
+   ```
+
+1. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
+
+```gradle
+compile project(':react-native-config-reader')
+```
+
+#### Android advanced configurations with Multiple environments
 
 If your app uses an `applicationIdSuffix` or a different `applicationId` depending on the build variants, you must append the following line inside the `buildTypes` block in your `android/app/build.gradle` file and specify your new package name.
 
-```
+```gradle
   resValue "string", "rn_config_reader_custom_package", "com.yourNewPackage"
 ```
 
 Example
 
-```
+```gradle
 buildTypes {
   ...
   debug {
@@ -134,11 +133,16 @@ buildTypes {
 }
 ```
 
-#### Windows (Beta)
-[Read it!](https://github.com/ReactWindows/react-native)
+### Windows (Beta)
+
+🚨 When this project was first created in early 2019, it offered support for a beta version of [React Native for Windows](https://github.com/microsoft/react-native-windows).  Since this time, many updates have been published to both `react-native` and `react-native-windows`, with no active updates in this project to ensure compatibility.
+
+🙏 If you're interested in using this library with `react-native-windows`, and can offer assistance maintaining it, please reach out to the maintainers by filing an issue.
 
 1. In Visual Studio add the `RNConfigReader.sln` in `node_modules/react-native-config-reader/windows/RNConfigReader.sln` folder to their solution, reference from their app.
-2. Open up your `MainPage.cs` app
+
+1. Open up your `MainPage.cs` app
+
   - Add `using Config.Reader.RNConfigReader;` to the usings at the top of the file
   - Add `new RNConfigReaderPackage()` to the `List<IReactPackage>` returned by the `Packages` method
 
@@ -156,10 +160,8 @@ If using Dexguard, the shrinking phase will remove resources it thinks are unuse
 
 `-keepresources string/rn_config_reader_custom_package`
 
-
 ## License
+
 MIT License
 
 Copyright (c) 2019 Chanaka Athurugiriya
-
-  

--- a/ios/RNConfigReader.h
+++ b/ios/RNConfigReader.h
@@ -1,8 +1,4 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNConfigReader : NSObject <RCTBridgeModule>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-config-reader",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Simply access android build configs and ios info.plist values in JS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "author": "csath - chanakaathurugiriya@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2 || ^0.60.0 || ^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
+    "react-native": "^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "csath - chanakaathurugiriya@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.61.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0"
+    "react-native": "^0.61.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,16 @@
     "ios",
     "config-reader"
   ],
-  "author": "csath - chanakaathurugiriya@gmail.com",
+  "author": {
+    "name": "Chanaka Athurugiriya",
+    "email": "chanakaathurugiriya@gmail.com"
+  },
+  "contributors": [
+    {
+      "name": "John Lianoglou",
+      "email": "prometheas+react-native-config-reader@gmail.com"
+    }
+  ],
   "license": "MIT",
   "peerDependencies": {
     "react-native": "^0.61.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-config-reader",
   "version": "5.0.0",
-  "description": "Simply access android build configs and ios info.plist values in JS",
+  "description": "Simply access Android build configs and iOS info.plist values in JS",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This fix for issue #40 makes the package compatible with Expo SDK 44+, but breaks backward compatibility with React Native versions less than 0.61.

BREAKING CHANGES