### PR TITLE
fix: update import of RCTBridge.h

### DIFF
--- a/ios/RNConfigReader.h
+++ b/ios/RNConfigReader.h
@@ -1,5 +1,5 @@
 #if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
+#import "React/RCTBridge.h"
 #else
 #import <React/RCTBridgeModule.h>
 #endif


### PR DESCRIPTION
Frankly, I don't know what drives the need for this change, but after updating React Native a project consuming this library from v0.64.2 to v0.68.2, the dependency failed to build until I applied this change with an error message that read, in part "property has a previous declaration"..

Some internet searching for this error message eventually got me to [this GitHub issue](https://github.com/mauron85/react-native-background-geolocation/issues/31) for a wholly-unrelated React Native project.  This small changed allowed the project to build, so here I am applying it.

😅